### PR TITLE
fix for sprite pos bug

### DIFF
--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -38,7 +38,7 @@ class PlayState extends FlxState
 	override public function update(elapsed:Float)
 	{
 		super.update(elapsed);
-		FlxG.collide(player, tel, playerTeleport);
+		FlxG.overlap(player, tel, playerTeleport);
 		FlxG.collide(player, walls);
 		FlxG.overlap(player, coins, playerTouchCoin);
 	}


### PR DESCRIPTION
remember that `FlxG.collide` calls `separate` automatically on the objects if they collide. to avoid this and just check if they overlap, just use FlxG.overlap.